### PR TITLE
Logscale fixes in scatter, pcolormesh and imshow

### DIFF
--- a/src/matplotgl/axes.py
+++ b/src/matplotgl/axes.py
@@ -345,7 +345,7 @@ class Axes(ipw.GridBox):
 
     def add_artist(self, artist):
         self._artists.append(artist)
-        self.scene.add(artist.get())
+        self.scene.add(artist._as_object3d())
 
     def get_figure(self):
         return self._fig

--- a/src/matplotgl/image.py
+++ b/src/matplotgl/image.py
@@ -63,7 +63,7 @@ class Image:
     def _update_colors(self) -> None:
         self._texture.data = self._make_colors()
 
-    def get(self) -> p3.Object3D:
+    def _as_object3d(self) -> p3.Object3D:
         return self._image
 
     def _set_xscale(self, scale: str) -> None:

--- a/src/matplotgl/line.py
+++ b/src/matplotgl/line.py
@@ -61,7 +61,7 @@ class Line:
         bottom, top = fix_empty_range(find_limits(self._y, scale=self._yscale, pad=pad))
         return {"left": left, "right": right, "bottom": bottom, "top": top}
 
-    def get(self):
+    def _as_object3d(self) -> p3.Object3D:
         out = []
         if self._line is not None:
             out.append(self._line)

--- a/src/matplotgl/mesh.py
+++ b/src/matplotgl/mesh.py
@@ -133,7 +133,7 @@ class Mesh:
         bottom, top = fix_empty_range(find_limits(self._y, scale=self._yscale, pad=pad))
         return {"left": left, "right": right, "bottom": bottom, "top": top}
 
-    def get(self) -> p3.Object3D:
+    def _as_object3d(self) -> p3.Object3D:
         return self._mesh
 
     def get_xdata(self) -> np.ndarray:

--- a/src/matplotgl/points.py
+++ b/src/matplotgl/points.py
@@ -148,7 +148,7 @@ class Points:
         bottom, top = fix_empty_range(find_limits(self._y, scale=self._yscale, pad=pad))
         return {"left": left, "right": right, "bottom": bottom, "top": top}
 
-    def get(self):
+    def _as_object3d(self) -> p3.Object3D:
         return self._points
 
     def get_xdata(self) -> np.ndarray:


### PR DESCRIPTION
Fixes the case where `ax.set_xscale('log')` is called before the artist is added to the axes.
This should now work:
```Py
import numpy as np
import matplotgl.pyplot as plt

x, y = np.random.normal(size=(2, 50_000))

fig, ax = plt.subplots()

ax.set_xscale('log')
ax.scatter(x, y)

fig
```